### PR TITLE
ЧАТ

### DIFF
--- a/lesson7/src/main/java/ru/jevo/chat/client/chatdraw/AppChat.java
+++ b/lesson7/src/main/java/ru/jevo/chat/client/chatdraw/AppChat.java
@@ -3,7 +3,6 @@ package ru.jevo.chat.client.chatdraw;
 import ru.jevo.chat.api.ChatSide;
  public class AppChat implements ChatSide
 {
-
     public void run(){
        // name = (args.length == 0) ? "unknown" : args[0];
       //  ChatDraw draw = new ChatDraw();


### PR DESCRIPTION
ПРи запуске третьего клиента  начинает подтупливать ClientMessageReadHandler . Проявляется это в том, что нажатие регистрации срабатывает только с третьей попытки, соответственно дальше все нажатия запаздывает на две итерации.